### PR TITLE
Allow users to override the owner group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Here is the list of all variables and their default values:
 - `pyenv_env: "user"` (should be either `"user"` or `"system"`)
 - `pyenv_path: "{% if pyenv_env == 'user' %}{{ ansible_env.HOME }}/pyenv{% else %}/usr/local/pyenv{% endif %}"`
 - `pyenv_owner: "{{ ansible_env.USER }}"`
+- `pyenv_owner_group: "{{ pyenv_owner }}"`
 - `pyenv_python_versions: [3.10.6]`
 - `pyenv_virtualenvs: [{ venv_name: latest, py_version: 3.10.6 }]`
 - `pyenv_global: [3.10.6]`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 pyenv_env: "user"
 pyenv_path: "{% if pyenv_env == 'user' %}{{ ansible_env.HOME }}/pyenv{% else %}/usr/local/pyenv{% endif %}"
 pyenv_owner: "{{ ansible_env.USER }}"
+pyenv_owner_group: "{{ pyenv_owner }}"
 pyenv_setting_path: "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"
 pyenv_update_git_install: true
 pyenv_enable_autocompletion: false

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -9,7 +9,7 @@
     src: templates/check-configure-options.py.j2
     dest: /etc/ansible/facts.d/check-configure-options.py
     owner: "{{ pyenv_owner }}"
-    group: "{{ pyenv_owner }}"
+    group: "{{ pyenv_owner_group }}"
     mode: "0755"
 
 - name: Copy over python_check fact file
@@ -17,7 +17,7 @@
     src: templates/pyenv_python_installations.fact.j2
     dest: /etc/ansible/facts.d/pyenv_python_installations.fact
     owner: "{{ pyenv_owner }}"
-    group: "{{ pyenv_owner }}"
+    group: "{{ pyenv_owner_group }}"
     mode: "0755"
 
 - name: Reload setup to gather custom facts


### PR DESCRIPTION
I'm experiencing some problems on Mac when the owner user doesn't have any associated groups with the same name:

```
TASK [staticdev.pyenv : Copy over check-configure-options.py] *************************************************************************************************************************************************************************************************
task path: /mnt/c/code/ansible-izo/ansible_roles/staticdev.pyenv/tasks/custom_facts.yml:7
fatal: [izo-sts-mac-02]: FAILED! => {"changed": false, "checksum": "8832f3169e82c52f2462e0fcee26f8eb496ec35a", "gid": 0, "group": "wheel", "mode": "0644", "msg": "chgrp failed: failed to look up group MY_USER", "owner": "MY_USER", "path": "/etc/ansible/facts.d/check-configure-options.py", "size": 194, "state": "file", "uid": 502}
```

Nice module btw :)