### PR TITLE
Parameter for Pyenv shellrc file named more descriptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ None.
       pyenv_version: "v2.3.9"
       pyenv_virtualenv_version: "v1.1.5"
       pyenv_update_version: "810db78"
-      pyenv_setting_path: "{{ ansible_env.HOME }}/.env"
+      pyenv_shellrc_file: "{{ ansible_env.HOME }}/.shrc"
       pyenv_path: "{{ ansible_env.HOME }}/.pyenv"
       pyenvrc_path: "{{ ansible_env.HOME }}"
       pyenv_owner: "{{ instance_owner }}"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Here is the list of all variables and their default values:
 - `pyenv_update_git_install: true` (get latest pyenv from git)
 - `pyenv_enable_autocompletion: false`
 - `pyenv_enable_virtualenvs: true`
-- `pyenv_setting_path: "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"`
+- `pyenv_shellrc_file "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"`
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ pyenv_path: "{% if pyenv_env == 'user' %}{{ ansible_env.HOME }}/pyenv{% else %}/
 pyenvrc_path: "{{ pyenv_path }}"
 pyenv_owner: "{{ ansible_env.USER }}"
 pyenv_owner_group: "{{ pyenv_owner }}"
-pyenv_setting_path: "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"
+pyenv_shellrc_file: "{% if pyenv_env == 'user' %}~/.bashrc{% else %}/etc/profile.d/pyenv.sh{% endif %}"
 pyenv_update_git_install: true
 pyenv_enable_autocompletion: false
 pyenv_enable_virtualenvs: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,15 +29,25 @@
     owner: "{{ pyenv_owner }}"
     mode: "0644"
 
-- name: "Load pyenv env variables in {{ pyenv_setting_path }}"
-  ansible.builtin.lineinfile: dest="{{ pyenv_setting_path }}"
+- name: Use legacy variable pyenv_setting_path if available
+  ansible.builtin.set_fact:
+    pyenv_shellrc_file: "{{ pyenv_setting_path }}"
+  when: pyenv_setting_path is defined
+
+- name: Print deprecation warning if pyenv_setting_path defined
+  ansible.builtin.debug:
+    msg: pyenv_setting_path is deprecated, use pyenv_shellrc_file instead
+  when: pyenv_setting_path is defined
+
+- name: "Load pyenv env variables in {{ pyenv_shellrc_file }}"
+  ansible.builtin.lineinfile: dest="{{ pyenv_shellrc_file }}"
     regexp="\.pyenvrc$"
     line="source {{ pyenvrc_path }}/.pyenvrc"
     state=present
     create=yes
 
-- name: "Add pyenv autocomplete in {{ pyenv_setting_path }}"
-  ansible.builtin.lineinfile: dest="{{ pyenv_setting_path }}"
+- name: "Add pyenv autocomplete in {{ pyenv_shellrc_file }}"
+  ansible.builtin.lineinfile: dest="{{ pyenv_shellrc_file }}"
     regexp="pyenv\.bash$"
     line="source {{ pyenv_path }}/completions/pyenv.bash"
     state=present


### PR DESCRIPTION
The parameter pyenv_setting_path is changed to pyenv_shellrc_file, which actually is what it is.

Added logic to keep backwards compability as well as print a deprecation warning. After suitable time the warning can be changed into a fail.