### PR TITLE
Allow updating the pyenv global versions file

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -104,4 +104,3 @@
       when:
         - _pyenv_globals_file.stat.exists
         - (_pyenv_globals_file_content.content | b64decode | split('\n') | select() | list) != pyenv_global
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -91,16 +91,17 @@
     pyenv_global_versions_path: "{{ pyenv_path }}/version"
   block:
     - name: "Does pyenv globals file exist?"
-      stat:
+      ansible.builtin.stat:
         path: "{{ pyenv_global_versions_path }}"
       register: _pyenv_globals_file
     - name: "Read the pyenv global versions"
-      slurp:
+      ansible.builtin.slurp:
         src: "{{ pyenv_global_versions_path }}"
       register: _pyenv_globals_file_content
       when: _pyenv_globals_file.stat.exists
     - name: "Set pyenv global {{ pyenv_global }}"
       ansible.builtin.shell: . {{ pyenvrc_path }}/.pyenvrc && pyenv global {{ pyenv_global | join(' ') }} && pyenv rehash
+      changed_when: true
       when:
         - _pyenv_globals_file.stat.exists
         - (_pyenv_globals_file_content.content | b64decode | split('\n') | select() | list) != pyenv_global

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -85,8 +85,23 @@
   with_items: "{{ pyenv_virtualenvs }}"
   when: pyenv_enable_virtualenvs
 
-- name: "Set pyenv global {{ pyenv_global }}"
-  ansible.builtin.shell: . {{ pyenvrc_path }}/.pyenvrc && pyenv global {{ pyenv_global | join(' ') }} && pyenv rehash
-  args:
-    creates: "{{ pyenv_path }}/version"
+- name: Update the pyenv globals
   when: pyenv_global is defined
+  vars:
+    pyenv_global_versions_path: "{{ pyenv_path }}/version"
+  block:
+    - name: "Does pyenv globals file exist?"
+      stat:
+        path: "{{ pyenv_global_versions_path }}"
+      register: _pyenv_globals_file
+    - name: "Read the pyenv global versions"
+      slurp:
+        src: "{{ pyenv_global_versions_path }}"
+      register: _pyenv_globals_file_content
+      when: _pyenv_globals_file.stat.exists
+    - name: "Set pyenv global {{ pyenv_global }}"
+      ansible.builtin.shell: . {{ pyenvrc_path }}/.pyenvrc && pyenv global {{ pyenv_global | join(' ') }} && pyenv rehash
+      when:
+        - _pyenv_globals_file.stat.exists
+        - (_pyenv_globals_file_content.content | b64decode | split('\n') | select() | list) != pyenv_global
+


### PR DESCRIPTION
Hello,

When setting the value of the `pyenv_global` variable to a different value than contained in the `"{{ pyenv_path }}/version"` file, the global version file is not updated. This is probably because of the following condition : https://github.com/staticdev/ansible-role-pyenv/blob/main/tasks/install.yml#L91 which skips running the command when the file already exists (https://docs.ansible.com/ansible/latest/collections/ansible/builtin/shell_module.html#parameter-creates)

We could remove that condition altogether, but this would always modify the file. We could also print & parse the globals as shown in this PR.

Let me know what you think!

(Also, thank you so much for maintaining this plugin!)
