### PR TITLE
Add check for pyenv_custom_pyenvrc_file

### DIFF
--- a/templates/.pyenvrc.j2
+++ b/templates/.pyenvrc.j2
@@ -59,6 +59,8 @@ export MAKE_INSTALL_OPTS="{{ pyenv_make_install_opts }}"
 {% if pyenv_profile_task is defined %}
 export PROFILE_TASK="{{ pyenv_profile_task }}"
 {% endif %}
+{% if pyenv_custom_pyenvrc_file is defined %}
 [ -f "{{ pyenvrc_path }}/.pyenvrc.custom" ] && source "{{ pyenvrc_path }}/.pyenvrc.custom"
+{% endif %}
 eval "$(pyenv init --path)"
 eval "$(pyenv init - {{ pyenv_init_options }})"


### PR DESCRIPTION
This is a very small change: it checks for `pyenv_custom_pyenvrc_file` into the main `pyenvrc` template.

Does not change functionality, as the sourcing of the custom pyenvrc file is behind a check.

However, it can lead someone astray when reading or debugging a pyenv system.

Additionally if someone would remove the `pyenv_custom_pyenvrc_file` from the role vars, the configuration would still apply (since the main config always checks for the file's existance).