### PR TITLE
Update Pre-commit hooks and enforce git fetch to be successful

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: check-toml
@@ -10,16 +10,16 @@ repos:
       - id: trailing-whitespace
       - id: check-added-large-files
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.27.1
+    rev: v1.35.1
     hooks:
       - id: yamllint
         args: ["-c=.yamllint", "."]
   - repo: https://github.com/ansible-community/ansible-lint.git
-    rev: v6.10.2
+    rev: v24.6.1
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$

--- a/.yamllint
+++ b/.yamllint
@@ -7,10 +7,16 @@ rules:
     level: warning
   braces:
     level: warning
+    max-spaces-inside: 1
   document-start:
     level: error
+  comments-indentation: false
   comments:
     level: error
+    min-spaces-from-content: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
   truthy:
     level: error
 

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: /etc/ansible/facts.d
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Copy over check-configure-options.py
   ansible.builtin.template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,6 +5,7 @@
     dest: "{{ pyenv_path }}"
     version: "{{ pyenv_version }}"
     update: "{{ pyenv_update_git_install }}"
+    force: true
 
 - name: Install PyEnv-virtualenv plugin
   ansible.builtin.git:
@@ -12,6 +13,7 @@
     dest: "{{ pyenv_path }}/plugins/pyenv-virtualenv"
     version: "{{ pyenv_virtualenv_version }}"
     update: "{{ pyenv_update_git_install }}"
+    force: true
   when: pyenv_enable_virtualenvs
 
 - name: Install PyEnv-update plugin
@@ -20,6 +22,7 @@
     dest: "{{ pyenv_path }}/plugins/pyenv-update"
     version: "{{ pyenv_update_version }}"
     update: "{{ pyenv_update_git_install }}"
+    force: true
   when: pyenv_update
 
 - name: Install .pyenvrc

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -53,7 +53,7 @@
     regexp: "\\.pyenvrc$"
     line: "source {{ pyenvrc_path }}/.pyenvrc"
     state: present
-    mode: 0644
+    mode: "0644"
     create: true
 
 - name: "Add pyenv autocomplete in {{ pyenv_shellrc_file }}"
@@ -61,33 +61,37 @@
     dest: "{{ pyenv_shellrc_file }}"
     regexp: "pyenv\\.bash$"
     line: "source {{ pyenv_path }}/completions/pyenv.bash"
-    mode: 0644
+    mode: "0644"
     state: present
   when: pyenv_enable_autocompletion
 
 - name: Update Pyenv interpreter list
-  ansible.builtin.shell: . {{ pyenvrc_path }}/.pyenvrc && pyenv update
+  ansible.builtin.shell:
+    cmd: . {{ pyenvrc_path }}/.pyenvrc && pyenv update
   register: output
   changed_when: "output.rc == 0"
   when: pyenv_update
 
 - name: Uninstall existing Python interpreters w/ wrong compilation flags
-  ansible.builtin.shell: ". {{ pyenvrc_path }}/.pyenvrc && pyenv uninstall -f {{ item }}"
+  ansible.builtin.shell:
+    cmd: ". {{ pyenvrc_path }}/.pyenvrc && pyenv uninstall -f {{ item }}"
   args:
     removes: "{{ pyenv_path }}/versions/{{ item }}/bin/python"
   loop: "{{ ansible_local['pyenv_python_installations']['to_reinstall'] | default([]) }}"
   when: pyenv_uninstall_python_w_wrong_configure_opts
 
 - name: "Install Python interpreters {{ pyenv_python_versions }}"
-  ansible.builtin.shell: ". {{ pyenvrc_path }}/.pyenvrc && pyenv install {{ pyenv_install_extra_opts }} {{ item }}"
+  ansible.builtin.shell:
+    cmd: ". {{ pyenvrc_path }}/.pyenvrc && pyenv install {{ pyenv_install_extra_opts }} {{ item }}"
   args:
     creates: "{{ pyenv_path }}/versions/{{ item }}/bin/python"
   with_items: "{{ pyenv_python_versions }}"
 
 - name: Create virtual environments
   ansible.builtin.shell:
-    . {{ pyenvrc_path }}/.pyenvrc && pyenv virtualenv {{ item.py_version }} {{ item.venv_name }}
-    creates="{{ pyenv_path }}/versions/{{ item.py_version }}/envs/{{ item.venv_name }}/bin/python"
+    cmd: . {{ pyenvrc_path }}/.pyenvrc && pyenv virtualenv {{ item.py_version }} {{ item.venv_name }}
+  args:
+    creates: "{{ pyenv_path }}/versions/{{ item.py_version }}/envs/{{ item.venv_name }}/bin/python"
   with_items: "{{ pyenv_virtualenvs }}"
   when: pyenv_enable_virtualenvs
 


### PR DESCRIPTION
I stumbled across the following error while running on our CI:

```
TASK [staticdev.pyenv : Install PyEnv] *****************************************
fatal: [sape.sap.example.com]: FAILED! => {"changed": false, "cmd": ["/usr/bin/git", "fetch", "--tags", "origin"], "msg": "Failed to download remote objects and refs:  From https://github.com/pyenv/pyenv\n   e8e8cfdd..38436116  master     -> origin/master\n * [new tag]           r          -> r\n ! [rejected]          v2.4.5     -> v2.4.5  (would clobber existing tag)\n"}
```

The reason is that the git module of ansible doesn't enforce the fetch on the one hand. On the other hand, pyenv changed the tag to a different commit and hence caused the trouble initially.

While reviewing the repository i found that pre-commit wasn't updated for a while and did that through `pre-commit autoupdate`. This updated a number of hooks in the repository. And these then led to new findings (mainly led by ansible-lint being updated).